### PR TITLE
More concurrency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
-                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojure "1.7.0"]
                  [tentacles "0.3.0"]]
   :main ^:skip-aot follow-git.core
   :target-path "target/%s"

--- a/src/follow_git/core.clj
+++ b/src/follow_git/core.clj
@@ -7,49 +7,49 @@
 (declare follow-unfollowed-users)
 
 (def auth (atom {}))
+(def per-page 100)
 
 (defn -main
-  "Takes in a user password combo with a repo to follow all the users in the repo that
+  "Takes in a user password combo with a org to follow all the users in the org that
   are not currently being followed"
-  [& [user password repo]]
+  [& [user password org]]
   (swap! auth assoc :auth (str user ":" password))
-  (follow-unfollowed-users user repo))
+  (follow-unfollowed-users org))
 
-(defn- entries-for-page [git-function search-term page] (git-function search-term (conj {:page page} @auth)))
+(defn- entries-for-page [git-function search-term page] (git-function search-term (conj {:page page :per-page per-page} @auth)))
 
-(defn all-entries [git-function search-term]
-  (future
-    (reduce (fn [coll curr]
+(defn- all-entries [git-function search-term]
+  (reduce (fn [coll curr]
               (let [entries (entries-for-page git-function search-term curr)]
-                (if (map? entries) (throw (Exception. (str "Github Error: " entries))))
-                (if (= (count entries) 0)
+              (if (map? entries) (throw (Exception. (str "Github Error: " entries))))
+              (if (= (count entries) 0)
                   (reduced coll)
                   (flatten (conj coll entries)))))
-             []
-             (iterate inc 1))))
-
-(defn users-following [user]
-  (println "Finding all followers")
-  (all-entries tentacles.users/following user))
+              []
+              (iterate inc 1)))
 
 (defn members-of-org [org]
   (println "Finding all members")
   (all-entries tentacles.orgs/members org))
 
-(defn- set-of-logins [users]
-  (into #{}
-        (map :login users)))
-
 (defn- follow [user]
   (println "Following user" user)
   (future (tentacles.users/follow user @auth)))
 
-(defn follow-unfollowed-users [user repo]
-    (let [followed (users-following user)
-          org-members (members-of-org repo)
-          unfollowed-users (s/difference (set-of-logins @org-members) (set-of-logins @followed))]
-      (doall (->> unfollowed-users
-                  (map follow)
-                  (map deref)))
-      (println "Newly followed users: " (count unfollowed-users))
+(defn- following? [user]
+  (future (tentacles.users/follow user @auth)))
+
+(defn follow-unfollowed-user [user]
+  (future (if (not (following? user))
+            (do (follow user) (println "following: " user))
+            false)))
+
+(defn follow-unfollowed-users [org]
+    (let [org-members (members-of-org org)]
+      (println "Newly followed user count: "
+               (doall (->> org-members
+                  (map :login)
+                  (map follow-unfollowed-user)
+                  (map deref)
+                  (filter true?))))
       (println "DONE")))


### PR DESCRIPTION
@spike01 thoughts? I've stopped querying for the users current followed users and just issue a query for every user in the org to check if you're following them and then follow if necessary. Quite a bit faster now but still stuck with the bottleneck of having to get alll users.
